### PR TITLE
FIX `dateFormat` and `placeHolder` methods are not chainable

### DIFF
--- a/src/DateRangeFilter.php
+++ b/src/DateRangeFilter.php
@@ -8,13 +8,13 @@ use Laravel\Nova\Filters\Filter;
 abstract class DateRangeFilter extends Filter
 {
     public $component = 'date-range-filter';
-    
+
     public function __construct()
     {
         $this->dateFormat('Y-m-d');
     }
-    
-    
+
+
     /**
      * Get the filter's available options.
      *
@@ -25,13 +25,14 @@ abstract class DateRangeFilter extends Filter
     {
         //
     }
-    
-    public function dateFormat($format){
-        $this->withMeta(['dateFormat' => $format]);
+
+    public function dateFormat($format)
+    {
+        return $this->withMeta(['dateFormat' => $format]);
     }
-    
+
     public function placeholder($placeholder)
     {
-        $this->withMeta(['placeholder' => $placeholder]);
+        return $this->withMeta(['placeholder' => $placeholder]);
     }
 }


### PR DESCRIPTION
The diff should be self explanatory but we are unable to add `->dateFormat()` or `->placeholder` in the return array of the `filters` method to add this filter to a resource.